### PR TITLE
Methods updated for ios7 fullscreen status bar style

### DIFF
--- a/Plugins/StatusBar.h
+++ b/Plugins/StatusBar.h
@@ -36,8 +36,8 @@
 #pragma mark - Instance methods
 
 - (void)show:(CDVInvokedUrlCommand*)command;
-- (void)opaque:(CDVInvokedUrlCommand*)command;
-- (void)translucent:(CDVInvokedUrlCommand*)command;
+- (void)blackTint:(CDVInvokedUrlCommand*)command;
+- (void)whiteTint:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/Plugins/StatusBar.m
+++ b/Plugins/StatusBar.m
@@ -29,27 +29,27 @@
 
 @synthesize callbackId = _callbackId;
 
-- (void)translucent:(CDVInvokedUrlCommand*)command {
+- (void)whiteTint:(CDVInvokedUrlCommand*)command {
   CDVPluginResult* pluginResult = nil;
 
-	self.callbackId = command.callbackId;
+    self.callbackId = command.callbackId;
   
   self.webView.backgroundColor = [UIColor whiteColor];
 
-  [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:NO];
-  [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleBlackTranslucent animated:YES];
+  [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:YES];
+  [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
   
 	pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)opaque:(CDVInvokedUrlCommand*)command {
+- (void)blackTint:(CDVInvokedUrlCommand*)command {
   CDVPluginResult* pluginResult = nil;
 
 	self.callbackId = command.callbackId;
   
-  [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:NO];
-  [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleBlackOpaque animated:NO];
+  [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:YES];
+  [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
   
 	pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/StatusBar.js
+++ b/StatusBar.js
@@ -17,12 +17,12 @@
     cordova.exec(callback, null, 'StatusBar', 'hide', []);
   };
  
-  StatusBar.prototype.translucent = function(callback) {
-    cordova.exec(callback, null, 'StatusBar', 'translucent', []);
+  StatusBar.prototype.whiteTint = function(callback) {
+    cordova.exec(callback, null, 'StatusBar', 'whiteTint', []);
   };
  
-  StatusBar.prototype.opaque = function(callback) {
-    cordova.exec(callback, null, 'StatusBar', 'opaque', []);
+  StatusBar.prototype.blackTint = function(callback) {
+    cordova.exec(callback, null, 'StatusBar', 'blackTint', []);
   };
 
   cordova.addConstructor(function() {


### PR DESCRIPTION
Methods updated for the new fullscreen Status Bar ios7 style. Changed the opaque and translucent, for white tint and black tint, hide and show remain the same as they still worked fine.
Tested in iphone 5 ios7 and xcode 5 with no issues in the code.
Maybe you still want to keep the old methods for backwards compatibility. 

window.plugins.statusBar.whiteTint();
window.plugins.statusBar.blackTint();
window.plugins.statusBar.hide();
window.plugins.statusBar.show();

regards!
